### PR TITLE
Add demos and workshops directory

### DIFF
--- a/demos_workshops/README.md
+++ b/demos_workshops/README.md
@@ -1,0 +1,18 @@
+The 2024 Symposium demo is here: https://github.com/openforcefield/symposium_2024_demo/
+
+The 2024 Mini Workshop materials are here:
+
+* The “Things to Make and Do with OpenFF” Workshop ([Youtube](https://www.youtube.com/watch?v=qs2cVX2rpD4&t=1s), [Zenodo](https://zenodo.org/records/11557676))
+* The “SMIRNOFF Force Fields and You” Workshop ([Youtube](https://www.youtube.com/watch?v=qpmxqjKHlzY), [Zenodo](https://zenodo.org/records/11557496))
+* The “Protein Preparation in Jupyter” Workshop ([Youtube](https://www.youtube.com/watch?v=pwfKE6wPaMg), [Zenodo](https://zenodo.org/records/11557619))
+
+The OpenFF Vignettes from the 2023 OMSF Workshop are here: https://github.com/openforcefield/2023-workshop-vignettes
+
+OpenFF's workshop materials for the 2023 CCPBioSim workshop are here: https://github.com/openforcefield/ccpbiosim-2023
+
+The hub page for the 2022 followup workshops is here: https://openforcefield.atlassian.net/wiki/spaces/MEET/pages/2416214017/2022+Follow-up+workshops
+
+* Materials for the PTM workshop are here: https://gist.github.com/Yoshanuikabundi/66007cb9966b1455a259baaf7cd7e7c3
+* Materials for the Interchange workshop are here: https://github.com/openforcefield/interchange-workshop-2022
+* Materials for the BespokeFit workshop are here: https://gist.github.com/Yoshanuikabundi/2860cf864ed1658ceec466bfb599e3fe
+


### PR DESCRIPTION
I tried to remember some recent demos and workshops, and pasted links to their materials in a readme. 