### PR TITLE
Fix non-bonded cutoff mismatch in Mg example

### DIFF
--- a/mix_openff_and_ommffs_components/mix_openff_and_ommffs_components.ipynb
+++ b/mix_openff_and_ommffs_components/mix_openff_and_ommffs_components.ipynb
@@ -56,8 +56,8 @@
     "system = forcefield.createSystem(pdb.topology, \n",
     "                                 nonbondedMethod=app.PME,\n",
     "                                 constraints=app.HBonds,\n",
-    "                                 nonbondedCutoff=0.9*openmm.unit.nanometer,\n",
-    "                                switchDistance=0.8*openmm.unit.nanometer)\n",
+    "                                 nonbondedCutoff=9.0*openmm.unit.angstrom,\n",
+    "                                switchDistance=8.0*openmm.unit.angstrom)\n",
     "# Currently, Interchange.from_openmm requires there to be _some_ force for these, even if they aren't used. \n",
     "system.addForce(openmm.HarmonicBondForce())\n",
     "system.addForce(openmm.HarmonicAngleForce())\n",
@@ -71,8 +71,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%env INTERCHANGE_EXPERIMENTAL=1\n",
-    "interchange_solv = Interchange.from_openmm(system, pdb.topology, positions=pdb.positions)"
+    "interchange_mg = Interchange.from_openmm(\n",
+    "    system=system,\n",
+    "    topology=pdb.topology,\n",
+    "    positions=pdb.positions,\n",
+    ")\n",
+    "\n",
+    "# Ensure the non-bonded settings match the `Interchange` created with Sage\n",
+    "interchange_mg['vdW'].cutoff = interchange_everything_else['vdW'].cutoff\n",
+    "interchange_mg['vdW'].switch_width = interchange_everything_else['vdW'].switch_width\n",
+    "interchange_mg['Electrostatics'].cutoff = interchange_everything_else['Electrostatics'].cutoff"
    ]
   },
   {
@@ -82,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interchange_all = interchange_everything_else.combine(interchange_solv)"
+    "interchange_all = interchange_everything_else.combine(interchange_mg)"
    ]
   },
   {


### PR DESCRIPTION
Changes

- [x] Drop `%env INTERCHANGE_EXPERIMENTAL=1`
- [x] Rename Mg-only object to `interchange_mg`
- [x] Force cutoffs to match before calling `Interchange.combine`

I ran this once without it obviously blowing up, and then again for 10 minutes - somehow this resulted in about 3 ns of simulation! - and nothing weird happened visually.