### PR TITLE
Add simpler protein-ligand NAGL example

### DIFF
--- a/simple-protein-ligand-nagl/simple-protein-ligand-nagl.ipynb
+++ b/simple-protein-ligand-nagl/simple-protein-ligand-nagl.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example demonstrates how to apply NAGL charges to a protein-ligand complex without anything more (relatively) complicated.\n",
+    "\n",
+    "This lifts heavily from the existing [BRD4 benchmark example](https://docs.openforcefield.org/en/latest/examples/openforcefield/openff-toolkit/using_smirnoff_with_amber_protein_forcefield/BRD4_inhibitor_benchmark.html) from the toolkit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "repo_url = (\n",
+    "    \"https://raw.githubusercontent.com/MobleyLab/benchmarksets/master/input_files/\"\n",
+    ")\n",
+    "sources = {\n",
+    "    \"receptor.pdb\": repo_url + \"BRD4/pdb/BRD4.pdb\",\n",
+    "    \"ligand.pdb\": repo_url + \"BRD4/pdb/ligand-1.pdb\",\n",
+    "    \"ligand.sdf\": repo_url + \"BRD4/sdf/ligand-1.sdf\",\n",
+    "}\n",
+    "for filename, url in sources.items():\n",
+    "    r = requests.get(url)\n",
+    "    open(filename, \"w\").write(r.text)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openff.toolkit import ForceField, Molecule, Topology\n",
+    "from openff.toolkit.utils.toolkits import NAGLToolkitWrapper, toolkit_registry_manager, ToolkitRegistry, RDKitToolkitWrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load the protein from PDB into a Topology object\n",
+    "topology = Topology.from_pdb(\"receptor.pdb\")\n",
+    "\n",
+    "# split the protein off into a distinct Molecule object for isolated charge assignment\n",
+    "protein = topology.molecule(0)\n",
+    "\n",
+    "# load the already-docked ligand and add it to the topology\n",
+    "topology.add_molecules([Molecule.from_file(\"ligand.sdf\")])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[12:22:45] ERROR: Too many atoms [did you forget 'LargeMolecules' switch?]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# need to provide both NAGL (for GCNN-based charge assignment) and RDKit (ONLY for SMARTS matching used by NAGL) wrapper\n",
+    "with toolkit_registry_manager(\n",
+    "    ToolkitRegistry([\n",
+    "        NAGLToolkitWrapper(), RDKitToolkitWrapper(),])):\n",
+    "    protein.assign_partial_charges(\n",
+    "        partial_charge_method=\"openff-gnn-am1bcc-0.1.0-rc.3.pt\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the SMIRNOFF port of ff14SB (whose charges won't be used) and Sage for protein and ligand, respectively\n",
+    "ff14sb_and_sage = ForceField(\"openff-2.2.1.offxml\", \"ff14sb_off_impropers_0.0.3.offxml\")\n",
+    "\n",
+    "interchange = ff14sb_and_sage.create_interchange(topology, charge_from_molecules=[protein])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e9d81287201c4e2f8f85a2802a2dd18c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NGLWidget()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "interchange.visualize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From here, you can prepare OpenMM, GROMACS, Amber, etc. simulations. See the [Interchange docs](https://docs.openforcefield.org/projects/interchange/en/stable/using/output.html) for more info."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
We have some other examples either doing more complex stuff (post-translational modifications) or not exactly operating on a protein-ligand complex (host-guest, ligand only, etc.). This is almost 100% recycled from existing content but I argue it's useful to have condensed in this targeted manner.